### PR TITLE
Add Node email template generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ vtex-email-builder/
 │       └── order-confirmation.hbs
 ├── dist/                    # HTML final gerado com CSS inline
 ├── build.js                 # Script que compila os e-mails
-├── create-templates.sh      # Cria automaticamente os templates B2C ou B2B
+├── createTemplates.js       # Cria automaticamente os templates B2C ou B2B
 ├── package.json
 └── README.md
 ```
@@ -55,13 +55,13 @@ Execute o script com o parâmetro para o tipo de template:
 - Para templates B2C:
 
 ```bash
-./create-templates.sh b2c
+npm run generate -- b2c
 ```
 
 - Para templates B2B:
 
 ```bash
-./create-templates.sh b2b
+npm run generate -- b2b
 ```
 
 O script cria os arquivos `.hbs` base em `src/templates/`, sem sobrescrever
@@ -72,7 +72,7 @@ arquivos existentes.
 ### 2. Compilar os e-mails
 
 ```bash
-node build.js
+npm run build
 ```
 
 Este comando:

--- a/createTemplates.js
+++ b/createTemplates.js
@@ -1,0 +1,73 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const TEMPLATES_B2C = [
+  'order-confirmation',
+  'order-invoiced',
+  'order-cancelled',
+  'payment-approved',
+  'payment-denied',
+  'order-shipping',
+  'order-delivered',
+  'cart-abandonment',
+  'customer-registration',
+  'password-reset',
+  'order-ready-for-pickup',
+  'invoice-available',
+  'exchange-requested',
+  'return-requested',
+  'subscription-renewed',
+  'gift-card-issued',
+  'ticket-created',
+  'order-on-hold'
+]
+
+const TEMPLATES_B2B = [
+  'b2b-order-confirmation',
+  'b2b-order-approval-request',
+  'b2b-order-approved',
+  'b2b-order-rejected',
+  'b2b-invoice-available',
+  'b2b-order-cancelled',
+  'b2b-payment-approved',
+  'b2b-payment-denied',
+  'b2b-delivery-scheduled',
+  'b2b-delivery-completed'
+]
+
+const type = process.argv[2]
+
+let templates
+if (type === 'b2c') {
+  templates = TEMPLATES_B2C
+} else if (type === 'b2b') {
+  templates = TEMPLATES_B2B
+} else {
+  console.error('Uso: node createTemplates.js [b2c|b2b]')
+  process.exit(1)
+}
+
+const templatesDir = path.join(__dirname, 'src', 'templates')
+fs.mkdirSync(templatesDir, { recursive: true })
+
+for (const name of templates) {
+  const file = path.join(templatesDir, `${name}.hbs`)
+  if (fs.existsSync(file)) {
+    console.log(`⚠️ Já existe: ${file}`)
+    continue
+  }
+  const content = `{{> header}}
+
+<!-- Conteúdo do e-mail ${name} -->
+<p>Olá, {{clientName}}!</p>
+
+{{> footer}}
+`
+  fs.writeFileSync(file, content)
+  console.log(`✔️ Criado: ${file}`)
+}
+

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "node build.js",
+    "generate": "node createTemplates.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `createTemplates.js` for generating template files with Node
- expose `build` and `generate` npm scripts
- document new workflow in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68508bcb138c832598850a333e887fe1