### PR TITLE
Add GitHub Action for building email templates

### DIFF
--- a/.github/workflows/build-email-templates.yml
+++ b/.github/workflows/build-email-templates.yml
@@ -1,0 +1,19 @@
+name: Build Email Templates
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: node build.js
+      - uses: actions/upload-artifact@v3
+        with:
+          name: compiled-emails
+          path: dist

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Este comando:
 - Gera os arquivos finais em `dist/*.html`
 - Mantém intactos os placeholders VTEX dentro dos templates principais (`{{}}`)
 
+### 3. Compilar pelo GitHub
+
+Também é possível gerar os HTMLs usando o GitHub Actions. Acesse a aba **Actions** do repositório e execute o workflow *Build Email Templates*. Ao fim da execução os arquivos da pasta `dist/` ficam disponíveis como artefato para download.
+
 ---
 
 ## ✏️ Customização


### PR DESCRIPTION
## Summary
- automate email generation with a GitHub Action
- document how to run the build via the Actions tab

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68508cce20948325a64a3804dbba83c6