### PR TITLE
Simplify email builder with CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ vtex-email-builder/
 │   └── templates/           # Templates de e-mails (.hbs)
 │       └── order-confirmation.hbs
 ├── dist/                    # HTML final gerado com CSS inline
-├── build.js                 # Script que compila os e-mails
-├── createTemplates.js       # Cria automaticamente os templates B2C ou B2B
+├── cli.js                   # Interface de linha de comando
+├── build.js                 # Função que compila os e-mails
+├── createTemplates.js       # Função que cria os templates B2C ou B2B
 ├── package.json
 └── README.md
 ```
@@ -52,16 +53,19 @@ npm install
 
 Execute o script com o parâmetro para o tipo de template:
 
+Também é possível usar o comando genérico `npm start <comando>` para acessar a
+CLI (ex.: `npm start build`).
+
 - Para templates B2C:
 
 ```bash
-npm run generate -- b2c
+npm run generate b2c
 ```
 
 - Para templates B2B:
 
 ```bash
-npm run generate -- b2b
+npm run generate b2b
 ```
 
 O script cria os arquivos `.hbs` base em `src/templates/`, sem sobrescrever

--- a/build.js
+++ b/build.js
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import { promises as fs } from 'fs'
 import path from 'path'
 import { fileURLToPath, pathToFileURL } from 'url'
 import * as sass from 'sass'
@@ -7,47 +7,56 @@ import juice from 'juice'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-const TEMPLATES_DIR = path.join(__dirname, 'src/templates')
-const DIST_DIR = path.join(__dirname, 'dist')
-const SCSS_FILE = path.join(__dirname, 'src/styles/main.scss')
-const HEADER_FILE = path.join(__dirname, 'src/partials/header.hbs')
-const FOOTER_FILE = path.join(__dirname, 'src/partials/footer.hbs')
+export async function build() {
+  const TEMPLATES_DIR = path.join(__dirname, 'src/templates')
+  const DIST_DIR = path.join(__dirname, 'dist')
+  const SCSS_FILE = path.join(__dirname, 'src/styles/main.scss')
+  const HEADER_FILE = path.join(__dirname, 'src/partials/header.hbs')
+  const FOOTER_FILE = path.join(__dirname, 'src/partials/footer.hbs')
 
-// Converte caminho para file:// URL
-const brandDataPath = path.join(__dirname, 'brandData.js')
-const brandDataUrl = pathToFileURL(brandDataPath).href
+  // Converte caminho para file:// URL
+  const brandDataPath = path.join(__dirname, 'brandData.js')
+  const brandDataUrl = pathToFileURL(brandDataPath).href
 
-// Importa o módulo com URL correta
-const brandDataModule = await import(brandDataUrl)
-const brandData = brandDataModule.default || brandDataModule
+  // Importa o módulo com URL correta
+  const brandDataModule = await import(brandDataUrl)
+  const brandData = brandDataModule.default || brandDataModule
 
-// 1. Compilar SCSS
-const compiledCss = sass.compile(SCSS_FILE).css
+  // 1. Compilar SCSS
+  const compiledCss = sass.compile(SCSS_FILE).css
 
-// 2. Ler parciais raw
-const headerRaw = fs.readFileSync(HEADER_FILE, 'utf8')
-const footerRaw = fs.readFileSync(FOOTER_FILE, 'utf8')
+  // 2. Ler parciais raw
+  const [headerRaw, footerRaw] = await Promise.all([
+    fs.readFile(HEADER_FILE, 'utf8'),
+    fs.readFile(FOOTER_FILE, 'utf8'),
+  ])
 
-// 3. Compilar parciais com brandData
-const headerHtml = handlebars.compile(headerRaw)(brandData)
-const footerHtml = handlebars.compile(footerRaw)(brandData)
+  // 3. Compilar parciais com brandData
+  const headerHtml = handlebars.compile(headerRaw)(brandData)
+  const footerHtml = handlebars.compile(footerRaw)(brandData)
 
-// 4. Processar templates principais
-fs.readdirSync(TEMPLATES_DIR).forEach(file => {
-  if (path.extname(file) !== '.hbs') return
+  // 4. Processar templates principais
+  const files = await fs.readdir(TEMPLATES_DIR)
+  await Promise.all(files.map(async file => {
+    if (path.extname(file) !== '.hbs') return
 
-  let templateRaw = fs.readFileSync(path.join(TEMPLATES_DIR, file), 'utf8')
+    let templateRaw = await fs.readFile(path.join(TEMPLATES_DIR, file), 'utf8')
 
-  // Substituir parciais compiladas
-  templateRaw = templateRaw.replace(/{{\s*header\s*}}/gi, headerHtml)
-                           .replace(/{{\s*footer\s*}}/gi, footerHtml)
+    // Substituir parciais compiladas
+    templateRaw = templateRaw.replace(/{{\s*header\s*}}/gi, headerHtml)
+                             .replace(/{{\s*footer\s*}}/gi, footerHtml)
 
-  // Inline CSS
-  const inlinedHtml = juice.inlineContent(templateRaw, compiledCss)
+    // Inline CSS
+    const inlinedHtml = juice.inlineContent(templateRaw, compiledCss)
 
-  // Salvar resultado
-  const outputFilePath = path.join(DIST_DIR, file.replace(/\.hbs$/, '.html'))
-  fs.writeFileSync(outputFilePath, inlinedHtml)
+    // Salvar resultado
+    const outputFilePath = path.join(DIST_DIR, file.replace(/\.hbs$/, '.html'))
+    await fs.writeFile(outputFilePath, inlinedHtml)
 
-  console.log(`✔️ Gerado: ${path.basename(outputFilePath)}`)
-})
+    console.log(`✔️ Gerado: ${path.basename(outputFilePath)}`)
+  }))
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  build()
+}

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,19 @@
+import { build } from './build.js'
+import { generateTemplates } from './createTemplates.js'
+
+const [,, command, arg] = process.argv
+
+async function run() {
+  if (command === 'build') {
+    await build()
+  } else if (command === 'generate') {
+    await generateTemplates(arg)
+  } else {
+    console.log('Usage: node cli.js <build|generate [b2c|b2b]>')
+  }
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "node build.js",
-    "generate": "node createTemplates.js"
+    "build": "node cli.js build",
+    "generate": "node cli.js generate",
+    "start": "node cli.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- refactor `build.js` and `createTemplates.js` to export async functions
- add `cli.js` with `build` and `generate` commands
- update package.json scripts to use the new CLI
- document CLI usage in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685092aed5e0832583b4269a744b0f9a