### PR TITLE
Add detailed placeholders to email templates

### DIFF
--- a/dist/b2b-delivery-completed.html
+++ b/dist/b2b-delivery-completed.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">A entrega do pedido B2B <strong>#{{orderNumber}}</strong> foi concluída.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/b2b-delivery-scheduled.html
+++ b/dist/b2b-delivery-scheduled.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">A entrega do pedido B2B <strong>#{{orderNumber}}</strong> foi agendada.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/b2b-invoice-available.html
+++ b/dist/b2b-invoice-available.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">A nota fiscal do pedido B2B <strong>#{{orderNumber}}</strong> está disponível.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/b2b-order-approval-request.html
+++ b/dist/b2b-order-approval-request.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{approverName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Foi criada uma solicitação de aprovação para o pedido <strong>#{{orderNumber}}</strong>.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/b2b-order-approved.html
+++ b/dist/b2b-order-approved.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">O pedido B2B <strong>#{{orderNumber}}</strong> foi aprovado.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/b2b-order-cancelled.html
+++ b/dist/b2b-order-cancelled.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">O pedido B2B <strong>#{{orderNumber}}</strong> foi cancelado.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/b2b-order-confirmation.html
+++ b/dist/b2b-order-confirmation.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Seu pedido B2B <strong>#{{orderNumber}}</strong> foi confirmado.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/b2b-order-rejected.html
+++ b/dist/b2b-order-rejected.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">O pedido B2B <strong>#{{orderNumber}}</strong> foi rejeitado.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/b2b-payment-approved.html
+++ b/dist/b2b-payment-approved.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">O pagamento do pedido B2B <strong>#{{orderNumber}}</strong> foi aprovado.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/b2b-payment-denied.html
+++ b/dist/b2b-payment-denied.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">O pagamento do pedido B2B <strong>#{{orderNumber}}</strong> foi negado.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/cart-abandonment.html
+++ b/dist/cart-abandonment.html
@@ -13,6 +13,23 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Você deixou itens no carrinho. Não perca, finalize sua compra!</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Itens do Carrinho</h2>
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+</table>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Total: {{totalValue}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Retome sua compra: <a href="{{returnUrl}}" style="color: #005eff; text-decoration: none;">{{returnUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/customer-registration.html
+++ b/dist/customer-registration.html
@@ -13,6 +13,13 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Seu cadastro foi concluído com sucesso.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Dados do Cadastro</h2>
+<ul>
+  <li>Nome: {{customerName}}</li>
+  <li>Email: {{clientEmail}}</li>
+  <li>Documento: {{customerDocument}}</li>
+  <li>Telefone: {{customerPhone}}</li>
+</ul>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/exchange-requested.html
+++ b/dist/exchange-requested.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Recebemos sua solicitação de troca para o pedido <strong>#{{orderNumber}}</strong>.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/gift-card-issued.html
+++ b/dist/gift-card-issued.html
@@ -13,6 +13,8 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Um cartão presente foi emitido para você.</p>
 
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Valor do gift card: {{giftCardValue}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Código do voucher: {{voucherCode}}</p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/invoice-available.html
+++ b/dist/invoice-available.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">A nota fiscal do pedido <strong>#{{orderNumber}}</strong> está disponível para download.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/order-cancelled.html
+++ b/dist/order-cancelled.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Informamos que seu pedido <strong>#{{orderNumber}}</strong> foi cancelado.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/order-confirmation.html
+++ b/dist/order-confirmation.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Seu pedido <strong>#{{orderNumber}}</strong> foi recebido com sucesso.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/order-delivered.html
+++ b/dist/order-delivered.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Seu pedido <strong>#{{orderNumber}}</strong> foi entregue com sucesso.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/order-invoiced.html
+++ b/dist/order-invoiced.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">A fatura referente ao pedido <strong>#{{orderNumber}}</strong> já está disponível.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/order-on-hold.html
+++ b/dist/order-on-hold.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Seu pedido <strong>#{{orderNumber}}</strong> está em espera.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/order-ready-for-pickup.html
+++ b/dist/order-ready-for-pickup.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Seu pedido <strong>#{{orderNumber}}</strong> está pronto para retirada.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/order-shipping.html
+++ b/dist/order-shipping.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Seu pedido <strong>#{{orderNumber}}</strong> foi enviado. Acompanhe o rastreamento: {{trackingCode}}</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/password-reset.html
+++ b/dist/password-reset.html
@@ -13,6 +13,7 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Recebemos uma solicitação para redefinir sua senha. Clique no link para continuar: {{resetLink}}</p>
 
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Para criar uma nova senha, clique no link: <a href="{{resetLink}}" style="color: #005eff; text-decoration: none;">{{resetLink}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/payment-approved.html
+++ b/dist/payment-approved.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Recebemos a confirmação do pagamento do pedido <strong>#{{orderNumber}}</strong>.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/payment-denied.html
+++ b/dist/payment-denied.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Infelizmente, o pagamento do pedido <strong>#{{orderNumber}}</strong> foi negado.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/return-requested.html
+++ b/dist/return-requested.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Recebemos sua solicitação de devolução para o pedido <strong>#{{orderNumber}}</strong>.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/subscription-renewed.html
+++ b/dist/subscription-renewed.html
@@ -13,6 +13,50 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Sua assinatura foi renovada com sucesso.</p>
 
+<h2 style="color: #005eff; margin: 0 0 8px 0; font-weight: normal;">Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%" style="width: 100%; border-collapse: collapse;">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td style="padding: 8px;">{{itemName}}</td>
+    <td align="center" style="padding: 8px;">{{itemQuantity}}</td>
+    <td align="right" style="padding: 8px;">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Subtotal</td>
+    <td align="right" style="padding: 8px;">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Frete</td>
+    <td align="right" style="padding: 8px;">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;">Desconto</td>
+    <td align="right" style="padding: 8px;">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right" style="padding: 8px;"><strong>Total</strong></td>
+    <td align="right" style="padding: 8px;"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de entrega: {{shippingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Endereço de cobrança: {{billingAddress}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Rastreio: <a href="{{trackingUrl}}" style="color: #005eff; text-decoration: none;">{{trackingUrl}}</a></p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Detalhes do pedido: <a href="{{orderUrl}}" style="color: #005eff; text-decoration: none;">{{orderUrl}}</a></p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/dist/ticket-created.html
+++ b/dist/ticket-created.html
@@ -13,6 +13,8 @@
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Olá {{customerName}},</p>
 <p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Seu ticket de suporte foi criado com sucesso.</p>
 
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Número do ticket: {{ticketId}}</p>
+<p style="margin: 0 0 16px 0; font-size: 14px; color: #333;">Pedido associado: {{orderId}}</p>
 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#f2f2f2" style="width: 100%; border-collapse: collapse; background-color: #f2f2f2; font-family: Arial, sans-serif; font-size: 14px; color: #555;">
   <tr>
     <td align="center" style="padding: 20px;">

--- a/src/templates/b2b-delivery-completed.hbs
+++ b/src/templates/b2b-delivery-completed.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>A entrega do pedido B2B <strong>#{{orderNumber}}</strong> foi concluída.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/b2b-delivery-scheduled.hbs
+++ b/src/templates/b2b-delivery-scheduled.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>A entrega do pedido B2B <strong>#{{orderNumber}}</strong> foi agendada.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/b2b-invoice-available.hbs
+++ b/src/templates/b2b-invoice-available.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>A nota fiscal do pedido B2B <strong>#{{orderNumber}}</strong> está disponível.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/b2b-order-approval-request.hbs
+++ b/src/templates/b2b-order-approval-request.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{approverName}},</p>
 <p>Foi criada uma solicitação de aprovação para o pedido <strong>#{{orderNumber}}</strong>.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/b2b-order-approved.hbs
+++ b/src/templates/b2b-order-approved.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>O pedido B2B <strong>#{{orderNumber}}</strong> foi aprovado.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/b2b-order-cancelled.hbs
+++ b/src/templates/b2b-order-cancelled.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>O pedido B2B <strong>#{{orderNumber}}</strong> foi cancelado.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/b2b-order-confirmation.hbs
+++ b/src/templates/b2b-order-confirmation.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>Seu pedido B2B <strong>#{{orderNumber}}</strong> foi confirmado.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/b2b-order-rejected.hbs
+++ b/src/templates/b2b-order-rejected.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>O pedido B2B <strong>#{{orderNumber}}</strong> foi rejeitado.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/b2b-payment-approved.hbs
+++ b/src/templates/b2b-payment-approved.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>O pagamento do pedido B2B <strong>#{{orderNumber}}</strong> foi aprovado.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/b2b-payment-denied.hbs
+++ b/src/templates/b2b-payment-denied.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>O pagamento do pedido B2B <strong>#{{orderNumber}}</strong> foi negado.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/cart-abandonment.hbs
+++ b/src/templates/cart-abandonment.hbs
@@ -4,4 +4,21 @@
 <p>Olá {{customerName}},</p>
 <p>Você deixou itens no carrinho. Não perca, finalize sua compra!</p>
 
+<h2>Itens do Carrinho</h2>
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+</table>
+<p>Total: {{totalValue}}</p>
+<p>Retome sua compra: <a href="{{returnUrl}}">{{returnUrl}}</a></p>
 {{footer}}

--- a/src/templates/customer-registration.hbs
+++ b/src/templates/customer-registration.hbs
@@ -4,4 +4,11 @@
 <p>Olá {{customerName}},</p>
 <p>Seu cadastro foi concluído com sucesso.</p>
 
+<h2>Dados do Cadastro</h2>
+<ul>
+  <li>Nome: {{customerName}}</li>
+  <li>Email: {{clientEmail}}</li>
+  <li>Documento: {{customerDocument}}</li>
+  <li>Telefone: {{customerPhone}}</li>
+</ul>
 {{footer}}

--- a/src/templates/exchange-requested.hbs
+++ b/src/templates/exchange-requested.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>Recebemos sua solicitação de troca para o pedido <strong>#{{orderNumber}}</strong>.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/gift-card-issued.hbs
+++ b/src/templates/gift-card-issued.hbs
@@ -4,4 +4,6 @@
 <p>Olá {{customerName}},</p>
 <p>Um cartão presente foi emitido para você.</p>
 
+<p>Valor do gift card: {{giftCardValue}}</p>
+<p>Código do voucher: {{voucherCode}}</p>
 {{footer}}

--- a/src/templates/invoice-available.hbs
+++ b/src/templates/invoice-available.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>A nota fiscal do pedido <strong>#{{orderNumber}}</strong> está disponível para download.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/order-cancelled.hbs
+++ b/src/templates/order-cancelled.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>Informamos que seu pedido <strong>#{{orderNumber}}</strong> foi cancelado.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/order-confirmation.hbs
+++ b/src/templates/order-confirmation.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>Seu pedido <strong>#{{orderNumber}}</strong> foi recebido com sucesso.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/order-delivered.hbs
+++ b/src/templates/order-delivered.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>Seu pedido <strong>#{{orderNumber}}</strong> foi entregue com sucesso.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/order-invoiced.hbs
+++ b/src/templates/order-invoiced.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>A fatura referente ao pedido <strong>#{{orderNumber}}</strong> já está disponível.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/order-on-hold.hbs
+++ b/src/templates/order-on-hold.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>Seu pedido <strong>#{{orderNumber}}</strong> está em espera.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/order-ready-for-pickup.hbs
+++ b/src/templates/order-ready-for-pickup.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>Seu pedido <strong>#{{orderNumber}}</strong> está pronto para retirada.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/order-shipping.hbs
+++ b/src/templates/order-shipping.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>Seu pedido <strong>#{{orderNumber}}</strong> foi enviado. Acompanhe o rastreamento: {{trackingCode}}</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/password-reset.hbs
+++ b/src/templates/password-reset.hbs
@@ -4,4 +4,5 @@
 <p>Olá {{customerName}},</p>
 <p>Recebemos uma solicitação para redefinir sua senha. Clique no link para continuar: {{resetLink}}</p>
 
+<p>Para criar uma nova senha, clique no link: <a href="{{resetLink}}">{{resetLink}}</a></p>
 {{footer}}

--- a/src/templates/payment-approved.hbs
+++ b/src/templates/payment-approved.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>Recebemos a confirmação do pagamento do pedido <strong>#{{orderNumber}}</strong>.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/payment-denied.hbs
+++ b/src/templates/payment-denied.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>Infelizmente, o pagamento do pedido <strong>#{{orderNumber}}</strong> foi negado.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/return-requested.hbs
+++ b/src/templates/return-requested.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>Recebemos sua solicitação de devolução para o pedido <strong>#{{orderNumber}}</strong>.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/subscription-renewed.hbs
+++ b/src/templates/subscription-renewed.hbs
@@ -4,4 +4,48 @@
 <p>Olá {{customerName}},</p>
 <p>Sua assinatura foi renovada com sucesso.</p>
 
+<h2>Detalhes do Pedido</h2>
+<ul>
+  <li>Número: {{orderId}}</li>
+  <li>Data: {{orderDate}}</li>
+  <li>Status: {{orderStatus}}</li>
+  <li>Método de pagamento: {{paymentMethod}}</li>
+  <li>Entrega: {{shippingMethod}} - {{deliveryDate}}</li>
+</ul>
+
+<table border="1" cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <th align="left">Item</th>
+    <th align="center">Qtd</th>
+    <th align="right">Preço</th>
+  </tr>
+  {{#each items}}
+  <tr>
+    <td>{{itemName}}</td>
+    <td align="center">{{itemQuantity}}</td>
+    <td align="right">{{itemPrice}}</td>
+  </tr>
+  {{/each}}
+  <tr>
+    <td colspan="2" align="right">Subtotal</td>
+    <td align="right">{{subtotal}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Frete</td>
+    <td align="right">{{shippingCost}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right">Desconto</td>
+    <td align="right">{{discount}}</td>
+  </tr>
+  <tr>
+    <td colspan="2" align="right"><strong>Total</strong></td>
+    <td align="right"><strong>{{totalValue}}</strong></td>
+  </tr>
+</table>
+
+<p>Endereço de entrega: {{shippingAddress}}</p>
+<p>Endereço de cobrança: {{billingAddress}}</p>
+<p>Rastreio: <a href="{{trackingUrl}}">{{trackingUrl}}</a></p>
+<p>Detalhes do pedido: <a href="{{orderUrl}}">{{orderUrl}}</a></p>
 {{footer}}

--- a/src/templates/ticket-created.hbs
+++ b/src/templates/ticket-created.hbs
@@ -4,4 +4,6 @@
 <p>Olá {{customerName}},</p>
 <p>Seu ticket de suporte foi criado com sucesso.</p>
 
+<p>Número do ticket: {{ticketId}}</p>
+<p>Pedido associado: {{orderId}}</p>
 {{footer}}


### PR DESCRIPTION
## Summary
- expand all templates to include order details and context variables
- regenerate compiled HTML with new content
- remove duplicate snippet from order-confirmation template

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850928af9f08325a480a7d25fe1a9ba