### PR TITLE
Add import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,14 @@ Este comando:
 ### 4. Importar templates do repositório oficial
 
 Caso deseje copiar os templates padrões disponibilizados em
-[`vtex/vtex-emails`](https://github.com/vtex/vtex-emails), execute o script
-abaixo em um ambiente com acesso à internet:
+[`vtex/vtex-emails`](https://github.com/vtex/vtex-emails), utilize o novo
+comando da CLI ou o script abaixo em um ambiente com acesso à internet:
 
 ```bash
+# via CLI Node
+npm run import
+
+# ou execute o script bash
 ./import-templates.sh
 ```
 

--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,6 @@
 import { build } from './build.js'
 import { generateTemplates } from './createTemplates.js'
+import { importTemplates } from './importTemplates.js'
 
 const [,, command, arg] = process.argv
 
@@ -8,8 +9,10 @@ async function run() {
     await build()
   } else if (command === 'generate') {
     await generateTemplates(arg)
+  } else if (command === 'import') {
+    await importTemplates()
   } else {
-    console.log('Usage: node cli.js <build|generate [b2c|b2b]>')
+    console.log('Usage: node cli.js <build|generate [b2c|b2b]|import>')
   }
 }
 

--- a/importTemplates.js
+++ b/importTemplates.js
@@ -1,0 +1,37 @@
+import { promises as fs } from 'fs';
+import { mkdtemp, rm } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const REPO_URL = 'https://github.com/vtex/vtex-emails.git';
+
+export async function importTemplates() {
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'vtex-emails-'));
+  try {
+    await execAsync(`git clone --depth=1 ${REPO_URL} ${tempDir}`);
+    const srcDir = path.join(tempDir, 'source', 'templates');
+    const destDir = path.join(__dirname, 'src', 'templates');
+    await fs.mkdir(destDir, { recursive: true });
+    const files = await fs.readdir(srcDir);
+    await Promise.all(
+      files.map(file => fs.copyFile(path.join(srcDir, file), path.join(destDir, file)))
+    );
+    console.log(`Templates copied to ${destDir}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  importTemplates().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "node cli.js build",
     "generate": "node cli.js generate",
+    "import": "node cli.js import",
     "start": "node cli.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- import official VTEX templates with Node
- expose new `import` command in CLI and package.json
- document how to import templates in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node cli.js import` *(fails to clone due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6852023cd2648325891dd7711eca7dfa